### PR TITLE
Idle timeout functionality

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -183,9 +183,12 @@ export default function Home() {
       }
     });
 
+    socket.addEventListener('error', (error) => {
+      console.error('WebSocket connection error:', error);
+    });    
 
     socket.addEventListener('close', (event) => {
-      console.log('WebSocket connection closed.', event.reason);
+      console.log('WebSocket connection closed: ', event.reason);
       if (event.reason === 'Client with this ID does not exist')
       {
         setError("id-not-found");
@@ -197,7 +200,7 @@ export default function Home() {
       disconnectClient();
     });};
 
-
+    
     const sendClientInfo = async () => {
       console.log('Sending client info...');
       var peerName = generatePeerName();

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -189,9 +189,9 @@ export default function Home() {
       if (event.reason === 'Client with this ID does not exist')
       {
         setError("id-not-found");
-      }
-      else 
-      {
+      } else if (event.reason === "Client idle timeout reached") {
+        setError("idle-timeout-reached")
+      } else {
         setError("server-error");
       }
       disconnectClient();
@@ -294,6 +294,9 @@ export default function Home() {
           }
           {error === "server-error" &&
             <div className='error'>Connection error. Please try again.</div>
+          }
+          {error === "idle-timeout-reached" && 
+            <div className='error'>Idle timeout reached. You have been disconnected.</div>
           }
           <button className='btn' onClick={() => setIsConnecting(true)}>Connect</button>
         </div>

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
 import { BiCopy } from 'react-icons/bi';
 import './style.css'
-import JSEncrypt from 'jsencrypt';
 
 const { subtle } = globalThis.crypto;
 
@@ -81,6 +80,7 @@ export default function Home() {
   const encrypt = async (message: string) => {
     let publicKeyBuffer = await subtle.exportKey("spki", peerPublicKey!)
     let publicKey = Buffer.from(publicKeyBuffer).toString('base64');
+    const JSEncrypt = (await import('jsencrypt')).default;
     const jsEncrypt = new JSEncrypt();
     jsEncrypt.setPublicKey(publicKey);
     return jsEncrypt.encrypt(message);
@@ -89,6 +89,7 @@ export default function Home() {
   const decrypt = async (message: string) => {
     let privateKeyBuffer = await subtle.exportKey("pkcs8", keyPair!.privateKey)
     let privateKey = Buffer.from(privateKeyBuffer).toString('base64');
+    const JSEncrypt = (await import('jsencrypt')).default;
     const jsEncrypt = new JSEncrypt();
     jsEncrypt.setPrivateKey(privateKey);
     return jsEncrypt.decrypt(message);
@@ -125,9 +126,12 @@ export default function Home() {
 
 
   const getUrl = () => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const id = urlParams.get('id');
-    return serverUrl + (id ? `?id=${id}` : '');
+    if(typeof window !== undefined) {
+      const urlParams = new URLSearchParams(window.location.search);
+      const id = urlParams.get('id');
+      return serverUrl + (id ? `?id=${id}` : '');
+    }
+    return serverUrl;
   }
 
   const connectWebSocket = () => {
@@ -236,7 +240,7 @@ export default function Home() {
     
     setHistory((prev: any) => [...prev, 'You: ' + text]);
 
-    let encryptedString = encrypt(text);
+    let encryptedString = await encrypt(text);
     socket.send("msg: " + encryptedString);
     setMessage('');
     setChatStarted(true);

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -27,7 +27,7 @@ func TestClient_closeConnection(t *testing.T) {
 	client2 := &Client{conn: conn2}
 	client1.pair = client2
 
-	err := client1.closeConnection()
+	err := client1.closeConnection(websocket.CloseAbnormalClosure, "Closing connection")
 
 	if err != nil {
 		t.Fatalf("closeConnection() returned an error: %v", err)

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -27,7 +27,7 @@ func TestClient_closeConnection(t *testing.T) {
 	client2 := &Client{conn: conn2}
 	client1.pair = client2
 
-	err := client1.closeConnection(websocket.CloseAbnormalClosure, "Closing connection")
+	err := client1.pair.closeConnection(websocket.CloseAbnormalClosure, "Closing connection")
 
 	if err != nil {
 		t.Fatalf("closeConnection() returned an error: %v", err)

--- a/server/server.go
+++ b/server/server.go
@@ -42,6 +42,9 @@ func (s *Server) process(flag chan bool) {
 func pairClients(client1, client2 *Client) {
 	client1.pair = client2
 	client2.pair = client1
+
+	client1.resetIdleTimer()
+	client2.resetIdleTimer()
 }
 
 func sendConnectedMessage(conn *websocket.Conn) {

--- a/server/server.go
+++ b/server/server.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-	"time"
 
 	"github.com/gorilla/websocket"
 )
@@ -20,8 +19,10 @@ func (s *Server) process(flag chan bool) {
 		case client := <-s.registerID:
 			peer, ok := s.clients[client.peerID]
 			if ok {
-				log.Println("Pairing clients")
+				log.Println("Paired clients")
 				pairClients(client, peer)
+
+				go client.handleTimeout()
 
 				// Send message to both clients that they are connected to change the state of the pages.
 				sendConnectedMessage(client.conn)
@@ -30,7 +31,7 @@ func (s *Server) process(flag chan bool) {
 				// Delete paired client from the queue.
 				delete(s.clients, client.peerID)
 			} else {
-				handleInvalidID(client)
+				client.closeConnection(websocket.CloseInternalServerErr, "Client with this ID does not exist")
 			}
 		case <-flag:
 			close(s.registerID)
@@ -49,9 +50,4 @@ func pairClients(client1, client2 *Client) {
 
 func sendConnectedMessage(conn *websocket.Conn) {
 	conn.WriteMessage(websocket.TextMessage, []byte("connected"))
-}
-
-func handleInvalidID(client *Client) {
-	client.conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "Client with this ID does not exist"), time.Now().Add(time.Second*5))
-	client.conn.Close()
 }


### PR DESCRIPTION
This pull request tries to resolve issue #17 "Server overloading protection measures" by implementing idle timeout which automatically disconnects unpaired or inactive clients after a specified period of time. Timeout duration for unpaired clients is a little longer.

Please review these changes, and I am looking forward to your feedback and suggestions.